### PR TITLE
Verify there are polisses with error to avoid execution error

### DIFF
--- a/invoicing/measurefixing/validacio_eines.py
+++ b/invoicing/measurefixing/validacio_eines.py
@@ -97,7 +97,9 @@ def buscar_errors_lot_ids(search_vals):
     search_vals += [('lot_id','=',lot_id)]
     clot_ids = clot_obj.search(search_vals)
     clot_reads = clot_obj.read(clot_ids,['polissa_id'])
-    pol_ids = sorted(list(set([clot_read['polissa_id'][0] for clot_read in clot_reads])))
+    pol_ids = []
+    if len(clot_ids) > 0:
+        pol_ids = sorted(list(set([clot_read['polissa_id'][0] for clot_read in clot_reads])))
     return pol_ids
 
 def polissaHasError(pol_id, text):


### PR DESCRIPTION
This script fail with the following error when the list of contract with errors is empty:

Running:/home/somenergia/somenergia/somenergia-scripts/invoicing/measurefixing/Validacio5_incompleta.py
Traceback (most recent call last):
  File "/home/somenergia/somenergia/somenergia-scripts/invoicing/measurefixing/Validacio5_incompleta.py", line 41, in <module>
    pol_ids = buscar_errors_lot_ids(search_vals)
  File "/home/somenergia/somenergia/invoice-janitor/invoicing/measurefixing/validacio_eines.py", line 100, in buscar_errors_lot_ids
    pol_ids = sorted(list(set([clot_read['polissa_id'][0] for clot_read in clot_reads])))
TypeError: 'bool' object is not iterable