### PR TITLE
Canvis al script de corvers molonguis

### DIFF
--- a/Curves/get_curves_info.py
+++ b/Curves/get_curves_info.py
@@ -160,13 +160,14 @@ def main(from_date, tariff):
     erp_fields = [
         'tg', 'distribuidora', 'autoconsumo', 'cups', 'data_alta',
         'data_ultima_lectura', 'tarifa', 'name',
-        'data_ultima_lectura_estimada', 'data_ultima_lectura_perfilada',
+        'data_ultima_lectura_estimada',
         'data_ultima_lectura_f1', 'tipo_medida',
     ]
 
     mongo_fields = get_mongo_fields()
     csv_name = 'curves_info_{}.csv'.format(datetime.now().strftime("%Y-%m-%d"))
-    csv_fields = erp_fields + ['data_avui'] + mongo_fields
+    csv_fields = erp_fields + ['data_ultima_lectura_factura_real', 'data_avui'] + mongo_fields
+    csv_fields.remove('data_ultima_lectura')
     step('creating csv...')
     create_csv(csv_name, csv_fields)
     step('Getting polissa data')
@@ -185,7 +186,9 @@ def main(from_date, tariff):
             cleared_polissa['data_avui'] = today
 
             lectura_F1ATR = polissa['data_ultima_lectura_f1']
+            cleared_polissa['data_ultima_lectura_factura_real'] = cleared_polissa['data_ultima_lectura']
             del cleared_polissa['id']
+            del cleared_polissa['data_ultima_lectura']
 
             if bool(lectura_F1ATR):
                 mongo_data_f5d = get_mongo_data(

--- a/scriptlauncher.yaml
+++ b/scriptlauncher.yaml
@@ -198,6 +198,16 @@ invoicefixing:
           extension: zip
           filename: cch_download.zip
 
+    get_curve_info:
+      script: python SOME_SRC/somenergia-scripts/Curves/get_curve_info.py --from_date {from_date} --tariff {tariff}' somenergia
+      title: CCh - Envia per email informació de les corves de cada contracte
+      description: Envia informació per cada contracte de vàries informacions (última lectura facturada F5D, última corba descaregada F1, etc...)
+      parameters:
+        from_date:
+          description: Introdueix la data d'inici del període que cal consultar 'YYYY-mm-dd'
+        tariff:
+          description: Introdueix la tarifa si vols filtrar per contractes amb una tarifa concreta
+
     # To Do: for future elimination, the ERP already can do the same and the script seems to be error prone
     #fixrefundinvoice:
     #  script:


### PR DESCRIPTION
Targeta on es demana: https://trello.com/c/FWfq605i/5010-0-2-p18-ep215-millores-en-extract-inventari-registres-cch-curvesinfo-alias-csv-molongui

- Afegir camp date_from (perquè no sempre retorni tot l'any)
- Canviar agree_tipus per tipo_medida que agafem de pólissa
- Afegir camp data_ultima_lectura_Facturada_deF1 > data_ultima_lectura_facturada_f1
data_ultima_lectura_F1ATR -> data_ultima_lectura_facturada_real
- Revisar pk count_cch_period_f5d retorna un registre més
- Sumar l'ai i la ao (de les pòlisses amb auto) de cada col·leccions per contracte.
- Afegir filtre per tarifa, per poder executar només pels d'una tarifa atr concreta
- Entrada a l'scriptlauncher per a que ho puguin executar ells, però revisar que estiguem apuntat a lectura
- Añada un elemento