### PR TITLE
Fix unsuscribe members script (emtpy mails + not starting with S)

### DIFF
--- a/admin/Baixa_Socis/unsubscribe_members.py
+++ b/admin/Baixa_Socis/unsubscribe_members.py
@@ -37,8 +37,7 @@ def get_not_members_email_list():
     category_id = get_member_category_id()
 
     not_members = Soci.search([
-        ('category_id', 'not in', [category_id]),
-        ('ref', 'like', 'S%')
+        ('category_id', 'not in', [category_id])
     ])
     not_members_partner_ids = [
         soci['partner_id'][0] for soci in Soci.read(not_members, ['partner_id'])
@@ -48,7 +47,7 @@ def get_not_members_email_list():
     )
 
     emails_list = [
-        address.get('email', 'not found')
+        address.get('email', 'not found') or 'empty'
         for address in ResPartnerAddress.read(address_list, ['email'])
     ]
 


### PR DESCRIPTION
Si el mail està buit, peta al fer el lower pel hash. Fent que quedi "empty", simplement no el troba a mailchimp, com els "not found".

També per saber qui NO es soci ara, estava mirant que NO tinguessin la categoria Soci però SÍ comencessin per S, i sabem que pot ser que algu que fos soci ara no ho tigui i comenci per T, per tant he tret aquesta condició també.

